### PR TITLE
Chage paginate.href(req) to use .originalUrl instead of url

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@
 // * Source: <https://github.com/niftylettuce/express-paginate>
 
 var querystring = require('querystring')
+var url = require('url');
 var _ = require('lodash')
 
 exports = module.exports
@@ -19,7 +20,7 @@ exports.href = function paginate(req) {
     prev = (typeof prev === 'boolean') ? prev : false
     query.page = prev ? query.page-= 1 : query.page += 1
     query.page = (query.page < 1) ? 1 : query.page
-    return req.originalUrl + '?' + querystring.stringify(query)
+    return url.parse(req.originalUrl).pathname + '?' + querystring.stringify(query)
   }
 }
 


### PR DESCRIPTION
If paginate.href(req) uses "url", it doesn't work when paginating inside routers.
For example:

``` javascript
app.use(paginate(10,50));

var router = express.Router();
router.route("/list");

app.use("/myroute", router);
```

When accessing "/myroute/list", `paginate.href()` will return `<a href="/list?page=2&limit=10">Next</a>`, when it should return `<a href="/list?page=2&limit=10">Next</a>`.
