### PR TITLE
Added NaN management

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ exports.middleware = function middleware(limit, maxLimit) {
 
     res.locals.paginate = {};
     res.locals.paginate.page = req.query.page;
-    res.locals.paginate.limit = req.query.page;
+    res.locals.paginate.limit = req.query.limit;
     res.locals.paginate.href = exports.href(req);
     res.locals.paginate.hasPreviousPages = req.query.page > 1;
     res.locals.paginate.hasNextPages = exports.hasNextPages(req);


### PR DESCRIPTION
If you request a page with a non numeric parameter it will convert it to NaN e all the API will stop working.
### Example

?page&limit
generates page === NaN and limit === NaN

I've fixed it using the default in this case.
