### PR TITLE
Support routers mounted in a certain path

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ exports.href = function href(req) {
     if (_.isObject(params))
       query = _.assign(query, params);
 
-    return url.parse(req.originalUrl).pathname + '?' + querystring.stringify(query);
+    return (req.baseUrl || '')+url.parse(req.originalUrl).pathname + '?' + querystring.stringify(query);
 
   };
 };

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -50,6 +50,24 @@ describe('paginate', function() {
 
   });
 
+  describe('.href(req) with mounted router', function() {
+
+    beforeEach(function() {
+      this.req = {
+        originalUrl: 'http://niftylettuce.com/',
+        query: {
+          page: 3
+        },
+        baseUrl: '/admin'
+      };
+    });
+
+    it('should return the next page when invoked with no arguments', function() {
+      paginate.href(this.req)().should.equal(util.format('%s%s?page=%d', this.req.baseUrl, url.parse(this.req.originalUrl).pathname, this.req.query.page + 1));
+    });
+
+  });
+
   describe('.hasNextPages(req)', function() {
 
     beforeEach(function() {


### PR DESCRIPTION
When mounting a router like this:

```javascript
var admin = express.Router()
admin.get(…)
app.use('/admin', admin)
```

The base url is stored in req.baseUrl and should be used when creating
URLs for pagination.