### PR TITLE
Fixed start and end bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,9 +68,9 @@ exports.getArrayPages = function(req) {
       throw new Error('express-paginate: `currentPage` is not a number >= 0');
 
     if (limit > 0) {
-      var start = currentPage - limit > 0 ? currentPage - limit : 1;
-      var end = currentPage + limit > maxPage ?
-        maxPage : currentPage + limit;
+      var end = Math.min(Math.max(currentPage + Math.floor(limit / 2), limit), pageCount);
+      var start = (currentPage < (limit - 1)) ? 1 : (end - limit) + 1;
+			
       var pages = [];
       for (var i = start; i <= end; i++) {
         pages.push({

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -154,7 +154,7 @@ describe('paginate', function() {
   describe('.getArrayPages(limit, pageCount, currentPaget)', function() {
 
     var pages;
-    var limit = 4,
+    var limit = 5,
       fakeMaxCount = 10;
 
     beforeEach(function() {


### PR DESCRIPTION
Makes sure the start and end are now correctly determined. It tries to keep the "current page button" in the middle of all page buttons. Also no more lower than zero browsing.
Also fixed up the test to correctly test this behavior.