### PR TITLE
Fixed cases where req.query.page doesnt get parsed into Number type

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ exports.href = function href(req) {
       prev = false;
     } else {
       prev = (typeof prev === 'boolean') ? prev : false;
+      query.page = Number.parseInt(query.page);
       query.page = prev ? query.page-= 1 : query.page += 1;
       query.page = (query.page < 1) ? 1 : query.page;
     }
@@ -64,7 +65,8 @@ exports.getArrayPages = function(req) {
     if (typeof pageCount !== 'number' || pageCount < 0)
       throw new Error('express-paginate: `pageCount` is not a number >= 0');
 
-    if (typeof currentPage !== 'number' || currentPage < 0)
+    currentPage = Number.parseInt(currentPage);
+    if(Number.isNaN(currentPage) || currentPage < 0)
       throw new Error('express-paginate: `currentPage` is not a number >= 0');
 
     if (limit > 0) {


### PR DESCRIPTION
I tried the example (either one) provided in the README file, one issue that came up was that `req.query` didnt automatically get parsed by express into Number types when possible, so when I passed `req.query.page` to `getArrayPages` it returned an error because `req.query.page` is a string value.

if I did parse it to a number and then passed it using ``getArrayPages(3, pageCount, Number.parseInt(req.query.page))`` a different issue will come up where `getArrayPages` will return an invalid url string since it uses the `href(req)` which contains the string type `req.query.page`:

```
[
    {
      "number": 1,
      "url": "/list?page=11&limit=10"
    },
    {
      "number": 2,
      "url": "/list?page=11&limit=10"
    },
    {
      "number": 3,
      "url": "/list?page=11&limit=10"
    }
  ]
```

Code example: (express v4.11.1)

```
let express = require('express');
let paginate = require('express-paginate');
let app = express();

app.use(paginate.middleware(10, 50));

app.get('/', (req, res, next) => {
  console.log(req.query, typeof req.query.page);
  // { page: '1', limit: '10' } 'string'
});

app.listen(3000);
```